### PR TITLE
Small fix for margin variable + subjects in mailto links

### DIFF
--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -612,7 +612,7 @@ Sélectionnez le format que vous souhaitez utiliser et cliquez sur « Exporter �
         font: "Police"
         font_face: "Caractère"
         font_size: "Taille"
-        margin: "Marge"
+        margin: "Marges"
         margins:
           top: "Haut"
           bottom: "Bas"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -507,13 +507,13 @@ Sélectionnez le format que vous souhaitez utiliser et cliquez sur « Exporter �
       project_text_when_no_project: "<p><strong>Bienvenue</strong></br> Vous êtes maintenant prêt à créer votre premier plan de gestion des données.</br>Cliquez sur le bouton « Créer un plan » ci-dessous pour commencer.</p>"
       project_text_when_project: "<p>Le tableau ci-dessous contient une liste des plans que vous avez créés et de ceux que d'autres personnes partagent avec vous.</br>Ces plans peuvent être modifiés, partagés, exportés ou supprimés en tout temps.</p>"
       confirmation_text: "Confirmer les renseignements sur le plan"   
-      confirmation_text_desc: "Vous utilisez le modèle générique de plan de gestion des données Portage. Si vous avez des suggestions pour améliorer ce modèle, ou si vous souhaiteriez ajouter de nouveaux modèles basés sur les exigences d'un organisme subventionnaire ou sur les besoins d'une discipline, communiquez avec nous à l'adresse suivante : <a href='mailto:portage@carl-abrc.ca?Subject=requete%20%20Assistant%20PGD'>portage@carl-abrc.ca</a>."
+      confirmation_text_desc: "Vous utilisez le modèle générique de plan de gestion des données Portage. Si vous avez des suggestions pour améliorer ce modèle, ou si vous souhaiteriez ajouter de nouveaux modèles basés sur les exigences d'un organisme subventionnaire ou sur les besoins d'une discipline, communiquez avec nous à l'adresse suivante : <a href='mailto:portage@carl-abrc.ca?Subject=requete%20Assistant%20PGD'>portage@carl-abrc.ca</a>."
       confirmation_button_text: "Oui, créer un plan"  
       project_details_text_html: "Cette page vous donne un aperçu de votre plan. Elle indique les éléments sur lesquels votre plan s'appuie et donne un aperçu des questions qui vous seront posées."
       project_details_editing_text_html: "<b>Répondre aux questions de base ci-dessous sur votre projet et cliquer sur 'Enregistrer' pour sauvegarder.</b>"
       confirm_delete_text: "Êtes-vous sûr de vouloir supprimer ce plan? En supprimant le plan de votre liste, il sera également supprimé de la liste de plans des personnes avec lesquelles le plan est partagé, le cas échéant."
       confirmation_text: "Confirmer les renseignements sur le plan"
-      confirmation_text_desc: "Vous utilisez le modèle générique de plan de gestion des données Portage. Si vous avez des suggestions pour améliorer ce modèle, ou si vous souhaiteriez ajouter de nouveaux modèles basés sur les exigences d'un organisme subventionnaire ou sur les besoins d'une discipline, communiquez avec nous à l'adresse suivante : <a href='mailto:portage@carl-abrc.ca?Subject=requete%20%20Assistant%20PGD'>portage@carl-abrc.ca</a>."
+      confirmation_text_desc: "Vous utilisez le modèle générique de plan de gestion des données Portage. Si vous avez des suggestions pour améliorer ce modèle, ou si vous souhaiteriez ajouter de nouveaux modèles basés sur les exigences d'un organisme subventionnaire ou sur les besoins d'une discipline, communiquez avec nous à l'adresse suivante : <a href='mailto:portage@carl-abrc.ca?Subject=requete%20Assistant%20PGD'>portage@carl-abrc.ca</a>."
       
       confirmation_button_text: "Oui, créer un plan"
       default_confirmation_text_desc: "Vous avez sélectionné le plan de gestion des données par défaut, qui est établi en fonction de la liste de vérification du Digital Curation Center (UK). Vous avez ainsi accès à une série générale de questions et de directives sur le plan de gestion des données. Pour de plus amples renseignements, consultez la : <a href='http://www.dcc.ac.uk/sites/default/files/documents/resource/DMP_Checklist_2013.pdf' target='_blank'>DMP checklist 2013 (Liste de vérification 2013 pour un plan de gestion des données)</a>."
@@ -654,7 +654,7 @@ L'Assistant PGD est un outil d'aide à la préparation d'un plan de gestion des 
     <div class='white_background'>
     <p> L'Assistant PGD comprend un modèle générique de plan de gestion des données, Portage, que les chercheurs peuvent utiliser. Des directives sont fournies afin de les aider à interpréter les questions et à y répondre.</p>
 
-p>Nous souhaitons obtenir vos commentaires! Si vous avez des suggestions sur la façon d'améliorer le modèle existant, ou si vous aimeriez ajouter d'autres modèles basés sur les exigences d'organismes de financement ou sur les besoins des disciplines, <a href='help#contact_info?locale=en'>communiquez avec votre établissement universitaire</a> ou communiquez avec nous à <a href='mailto:portage@carl-abrc.ca?Subject=Commentaires%20%Assistant%20PGD'>portage@carl-abrc.ca</a>.
+    <p>Nous souhaitons obtenir vos commentaires! Si vous avez des suggestions sur la façon d'améliorer le modèle existant, ou si vous aimeriez ajouter d'autres modèles basés sur les exigences d'organismes de financement ou sur les besoins des disciplines, <a href='help#contact_info?locale=fr'>communiquez avec votre établissement universitaire</a> ou communiquez avec nous à <a href='mailto:portage@carl-abrc.ca?Subject=Commentaires%20Assistant%20PGD'>portage@carl-abrc.ca</a>.
 
     </p>
     </div>
@@ -669,7 +669,7 @@ p>Nous souhaitons obtenir vos commentaires! Si vous avez des suggestions sur la 
     </div>
     <h3>Commentaires</h3>
     <div class='white_background'>
-    <p>Si vous avez des questions ou des commentaires au sujet de l'Assistant PGD, <a href='help#contact_info?locale=en'>communiquez avec votre établissement universitaire</a> ou communiquez avec nous par courriel à <a href='mailto:portage@carl-abrc.ca?Subject=Commentaires%20%Assistant%20PGD'>portage@carl-abrc.ca</a>.</p>
+    <p>Si vous avez des questions ou des commentaires au sujet de l'Assistant PGD, <a href='help#contact_info?locale=fr'>communiquez avec votre établissement universitaire</a> ou communiquez avec nous par courriel à <a href='mailto:portage@carl-abrc.ca?Subject=Commentaires%20Assistant%20PGD'>portage@carl-abrc.ca</a>.</p>
     </div>"
 
 


### PR DESCRIPTION
Shouldn't this be "margins" (plural form) also in the English file?