### PR TITLE
Updating gems to fix security warning generated by gemnasium

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,14 +29,14 @@ gem 'less-rails'
 
 gem 'twitter-bootstrap-rails', '~> 2.2.8'
 gem 'sass-rails',   '~> 3.2.3'
-gem 'sass' 
+gem 'sass'
 
 gem 'jquery-rails'
 #gem 'jquery-ui-rails'
 
 gem 'tinymce-rails'
 gem 'friendly_id'
-gem 'contact_us' 
+gem 'contact_us'
 
 #implementation of forms
 gem 'activeadmin', '1.0.0.pre1'
@@ -80,12 +80,12 @@ gem 'htmltoword'
 # gem 'debugger'
 
 group :development, :test do
-  gem 'rspec-rails' 
+  gem 'rspec-rails'
   gem 'rspec'
   gem 'selenium-webdriver'
-  gem 'mail'
+  gem 'mail', '~> 2.5.5'
   gem 'pdf-reader'
-  gem 'nokogiri'
+  gem 'nokogiri', '~> 1.7.2'
 end
 
 group :production do

--- a/Gemfile
+++ b/Gemfile
@@ -83,8 +83,12 @@ group :development, :test do
   gem 'rspec-rails'
   gem 'rspec'
   gem 'selenium-webdriver'
+
+  # pint this to issue 115 - security warning
   gem 'mail', '~> 2.5.5'
   gem 'pdf-reader'
+
+  # pint this to issue 115 - security warning
   gem 'nokogiri', '~> 1.7.2'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,16 +147,15 @@ GEM
       actionpack (>= 3.1)
       less (~> 2.6.0)
     libv8 (3.11.8.17)
-    mail (2.5.4)
+    mail (2.5.5)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
     mime-types (1.25.1)
     mini_portile2 (2.1.0)
     multi_json (1.12.1)
     mysql2 (0.3.21)
-    nokogiri (1.6.8)
+    nokogiri (1.7.2)
       mini_portile2 (~> 2.1.0)
-      pkg-config (~> 1.1.7)
     omniauth (1.3.1)
       hashie (>= 1.2, < 4)
       rack (>= 1.0, < 3)
@@ -169,7 +168,6 @@ GEM
       hashery (~> 2.0)
       ruby-rc4
       ttfunk
-    pkg-config (1.1.7)
     polyamorous (1.3.1)
       activerecord (>= 3.0)
     polyglot (0.3.5)
@@ -306,9 +304,9 @@ DEPENDENCIES
   ledermann-rails-settings
   less-rails
   libv8
-  mail
+  mail (~> 2.5.5)
   mysql2 (~> 0.3.20)
-  nokogiri
+  nokogiri (~> 1.7.2)
   omniauth
   omniauth-shibboleth
   pdf-reader
@@ -329,3 +327,6 @@ DEPENDENCIES
   uglifier
   validate_url
   wicked_pdf
+
+BUNDLED WITH
+   1.15.1


### PR DESCRIPTION
issue command 
```shell
bundle update nokogiri
bundle update mail
```
to update to new version of gems