### PR TITLE
missing commits and fixes since tagged release v4.2-1.44.el6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,9 @@ gem 'i18n'
 gem 'globalize', '~>3.1.0'
 gem 'dragonfly'
 
+# added rollbar for log monitoring
+gem 'rollbar'
+
 # Gems used only for assets and not required
 # in production environments by default.
 group :assets do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -208,6 +208,8 @@ GEM
     responders (1.1.2)
       railties (>= 3.2, < 4.2)
     rolify (5.1.0)
+    rollbar (2.15.4)
+      multi_json
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
@@ -313,6 +315,7 @@ DEPENDENCIES
   rails (~> 3.2.22)
   recaptcha
   rolify
+  rollbar
   rspec
   rspec-rails
   rubyzip (~> 1.2.1)

--- a/app/views/plans/_answer_form.html.erb
+++ b/app/views/plans/_answer_form.html.erb
@@ -225,9 +225,9 @@
                                 <a class="accordion-guidance-link" data-toggle="collapse" data-parent="#<%= question.id %>-guidance" href="#collapse-guidance-<%= group.id%>-<%= guidance.id%>-<%= question.id %>">
                                     <div class="accordion_heading_text">
                                     <% if theme == "no_theme" then %>
-                                        <%= group.name.chomp(" guidance") %> guidance
+                                        <%= group.name.chomp(" guidance") %> 
                                     <% else %>
-                                        <%= group.name.chomp(" guidance") %> guidance on <%= theme.title %>
+                                        <%= group.name.chomp(" guidance") %> - <%= theme.title %>
                                     <% end %>
                                     </div>
                                     <span class="plus-laranja"> </span></a>


### PR DESCRIPTION
Rollbar deployment was missing in the deployment-portage branch and the tagged releases since .44. possibly a rebase wasn't done properly when 2 PRs were opened at the same time. @astrilet  