### PR TITLE
fixing SMPT error

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -54,8 +54,8 @@ DMPonline4::Application.configure do
 	 config.middleware.use ExceptionNotification::Rack,
 	  :email => {
 	    :email_prefix => "[DMPonline4 ERROR] ",
-	    :sender_address => %{"No-reply" ENV["EXCEPT_SENDER"]},
-	    :exception_recipients => %w{ENV["EXCEPT_RECIPIENTS"]}
+	    :sender_address => ENV["EXCEPT_SENDER"],
+	    :exception_recipients => ENV["EXCEPT_RECIPIENTS"]
 	  }
 
   config.action_mailer.perform_deliveries = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -87,8 +87,8 @@ DMPonline4::Application.configure do
          config.middleware.use ExceptionNotification::Rack,
           :email => {
             :email_prefix => "[DMPonline4 ERROR] ",
-            :sender_address => %{"No-reply" ENV["EXCEPT_SENDER"]},
-            :exception_recipients => %w{ENV["EXCEPT_RECIPIENTS"]}
+            :sender_address => ENV["EXCEPT_SENDER"],
+            :exception_recipients => ENV["EXCEPT_RECIPIENTS"]
           }
 
 

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -87,8 +87,8 @@ DMPonline4::Application.configure do
          config.middleware.use ExceptionNotification::Rack,
           :email => {
             :email_prefix => "[DMPonline4 ERROR] ",
-            :sender_address => %{"No-reply" ENV["EXCEPT_SENDER"]},
-            :exception_recipients => %w{ENV["EXCEPT_RECIPIENTS"]}
+            :sender_address => ENV["EXCEPT_SENDER"],
+            :exception_recipients => ENV["EXCEPT_RECIPIENTS"]
           }
 
 


### PR DESCRIPTION
following error showed when trying to test rollbar (bundle exec rake rollbar:test)

An error occurred when sending a notification using 'email' notifier. Net::SMTPFatalError: 553 5.5.4 <ENV["EXCEPT_SENDER"]>... Domain name required for sender address ENV[EXCEPT_SENDER]