### PR TITLE
Bump recaptcha from 3.3.0 to 3.4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'omniauth'
 gem 'omniauth-shibboleth'
 # pin recaptcha to work with Ruby 2.1 and Rails 3
 # some work is required to upgrade to 4.9. So pinned it to 3.x for now
-gem 'recaptcha', '~>3'
+gem 'recaptcha', '3.4.0'
 gem 'i18n'
 gem 'globalize', '~>3.1.0'
 gem 'dragonfly'

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,9 @@ gem 'rubyzip', '~> 1.2.2'
 gem 'mysql2', '~>0.3.20'
 gem 'omniauth'
 gem 'omniauth-shibboleth'
-gem 'recaptcha'
+# pin recaptcha to work with Ruby 2.1 and Rails 3
+# some work is required to upgrade to 4.9. So pinned it to 3.x for now
+gem 'recaptcha', '~>3'
 gem 'i18n'
 gem 'globalize', '~>3.1.0'
 gem 'dragonfly'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -209,7 +209,7 @@ GEM
       polyamorous (~> 1.3)
     rdoc (3.12.2)
       json (~> 1.4)
-    recaptcha (3.3.0)
+    recaptcha (3.4.0)
       json
     ref (2.0.0)
     responders (1.1.2)
@@ -321,7 +321,7 @@ DEPENDENCIES
   omniauth-shibboleth
   pdf-reader
   rails (~> 3.2.22)
-  recaptcha
+  recaptcha (~> 3)
   rolify
   rollbar
   rspec


### PR DESCRIPTION
Update recaptcha but have to pin it down to 3.X to work with Ruby 2.1 and Rails 3, as some work is required to upgrade to 4.9.