### PR TITLE
upgrade wicked_pdf from 1.0.6 to 1.1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,7 +66,7 @@ gem 'validate_url'
 # gem 'sword2ruby'
 
 gem 'thin'
-gem 'wicked_pdf'
+gem 'wicked_pdf', '~>1.2.0'
 gem 'htmltoword'
 # To use ActiveModel has_secure_password
 # gem 'bcrypt-ruby', '~> 3.0.0'

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,8 @@ gem 'rails', '~>3.2.22'
 
 # pin this to post-CVE 2017-5946
 gem 'rubyzip', '~> 1.2.2'
+# pin the following gems to work with Ruby 2.1 and Rails 3
+gem 'public_suffix','~>3.0.3'
 
 gem 'mysql2', '~>0.3.20'
 gem 'omniauth'

--- a/Gemfile
+++ b/Gemfile
@@ -68,7 +68,7 @@ gem 'validate_url'
 # gem 'sword2ruby'
 
 gem 'thin'
-gem 'wicked_pdf', '~>1.2.0'
+gem 'wicked_pdf', '1.1.0'
 gem 'htmltoword'
 # To use ActiveModel has_secure_password
 # gem 'bcrypt-ruby', '~> 3.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -285,7 +285,8 @@ GEM
     warden (1.2.6)
       rack (>= 1.0)
     websocket (1.2.3)
-    wicked_pdf (1.0.6)
+    wicked_pdf (1.2.2)
+      activesupport
 
 PLATFORMS
   ruby
@@ -337,7 +338,7 @@ DEPENDENCIES
   twitter-bootstrap-rails (~> 2.2.8)
   uglifier
   validate_url
-  wicked_pdf
+  wicked_pdf (~> 1.2.0)
 
 BUNDLED WITH
    1.16.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -287,8 +287,7 @@ GEM
     warden (1.2.6)
       rack (>= 1.0)
     websocket (1.2.3)
-    wicked_pdf (1.2.2)
-      activesupport
+    wicked_pdf (1.1.0)
 
 PLATFORMS
   ruby
@@ -341,7 +340,7 @@ DEPENDENCIES
   twitter-bootstrap-rails (~> 2.2.8)
   uglifier
   validate_url
-  wicked_pdf (~> 1.2.0)
+  wicked_pdf (= 1.1.0)
 
 BUNDLED WITH
    1.16.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,7 +42,8 @@ GEM
     activesupport (3.2.22.5)
       i18n (~> 0.6, >= 0.6.4)
       multi_json (~> 1.0)
-    addressable (2.4.0)
+    addressable (2.6.0)
+      public_suffix (>= 2.0.2, < 4.0)
     afm (0.2.2)
     amoeba (3.1.0)
       activerecord (>= 3.2.6)
@@ -178,6 +179,7 @@ GEM
     polyamorous (1.3.1)
       activerecord (>= 3.0)
     polyglot (0.3.5)
+    public_suffix (3.0.3)
     rack (1.4.7)
     rack-cache (1.9.0)
       rack (>= 0.4)
@@ -279,9 +281,9 @@ GEM
     tzinfo (0.3.55)
     uglifier (3.0.1)
       execjs (>= 0.3.0, < 3)
-    validate_url (1.0.2)
+    validate_url (1.0.8)
       activemodel (>= 3.0.0)
-      addressable
+      public_suffix
     warden (1.2.6)
       rack (>= 1.0)
     websocket (1.2.3)
@@ -320,6 +322,7 @@ DEPENDENCIES
   omniauth
   omniauth-shibboleth
   pdf-reader
+  public_suffix (~> 3.0.3)
   rails (~> 3.2.22)
   recaptcha
   rolify


### PR DESCRIPTION
Can't upgrade to latest version without deep investigation. Upgrading to 1.1.0 for now. 